### PR TITLE
Run tests while loopback api is running already

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,15 @@ module.exports = {
     if (typeof conf !== 'object') {
       return callback('Failed to load test configuration from file');
     }
+    if(app){
+      before(function(done) {
+        server = app.listen(done);
+      });
 
-    before(function(done) {
-      server = app.listen(done);
-    });
-
-    after(function(done) {
-      server.close(done);
-    });
+      after(function(done) {
+        server.close(done);
+      });
+    }
 
     describe('Loopback API', function() {
       async.each(conf, function(c, asyncCallback) {


### PR DESCRIPTION
If the api is already running this change enables it to not run again and cause an **EADDRINUSE** error, just send null as the second param of the run function, example:  

```
loopbackApiTesting.run(tests,` null, url, function(err) {
  if (err) {
    console.log(err);
  }
});
```
